### PR TITLE
Include the current git version in comipiled jars

### DIFF
--- a/RobotCode/MecanumDrive/build.xml
+++ b/RobotCode/MecanumDrive/build.xml
@@ -20,11 +20,23 @@
   <!-- <property name="target" value=""/> -->
 
   <!-- Any other property in build.properties can also be overridden. -->
+	
+  <!-- inspired by http://llbit.se/?p=1876 -->
+  <!-- get a new version string using git describe if possible -->
+  <echo message="Updating version string..."/>
+  <exec executable="git" outputproperty="code-version" failifexecutionfails="true">
+  	<!-- `git rev-parse head' echoes the entire SHA hash. Future versions of this will use git describe to show current tag version too. -->
+    <arg line="rev-parse head"/>
+  </exec>
+  <echo message="Version string found: ${code-version}" />
   
   <property file="${user.home}/wpilib/wpilib.properties"/>
   <property file="build.properties"/>
   <property file="${user.home}/wpilib/java/${version}/ant/build.properties"/>
   
-  <import file="${wpilib.ant.dir}/build.xml"/>
+  <!-- <import file="${wpilib.ant.dir}/build.xml"/> -->
+  <!-- We need to use a custom script for versions. -->
+
+  <import file="custom_wpi_build.xml" />
 
 </project> 

--- a/RobotCode/MecanumDrive/build.xml
+++ b/RobotCode/MecanumDrive/build.xml
@@ -25,8 +25,7 @@
   <!-- get a new version string using git describe if possible -->
   <echo message="Updating version string..."/>
   <exec executable="git" outputproperty="code-version" failifexecutionfails="true">
-  	<!-- `git rev-parse head' echoes the entire SHA hash. Future versions of this will use git describe to show current tag version too. -->
-    <arg line="rev-parse head"/>
+    <arg line="describe --tags"/>
   </exec>
   <echo message="Version string found: ${code-version}" />
   

--- a/RobotCode/MecanumDrive/custom_wpi_build.xml
+++ b/RobotCode/MecanumDrive/custom_wpi_build.xml
@@ -1,0 +1,238 @@
+<!-- 
+NONE OF THIS IS MINE. This is the standard WPI build script with two small additions at lines 94 and 154. Go bug them if it doesn't work!
+-->
+
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project name="athena-project-build" default="deploy">
+
+  <!-- Load Tasks -->
+  <taskdef resource="net/sf/antcontrib/antlib.xml">
+    <classpath>
+      <pathelement location="${wpilib.ant.dir}/ant-contrib.jar"/>
+    </classpath>
+  </taskdef>
+  <taskdef resource="net/jtools/classloadertask/antlib.xml" classpath="${classloadertask.jar}"/>
+  <classloader loader="system" classpath="${jsch.jar}"/>
+
+  <target name="clean" description="Clean up all build and distribution artifacts.">
+    <delete dir="${build.dir}"/>
+    <delete dir="${dist.dir}"/>
+  </target>
+
+  <!-- Targets -->
+
+  <target name="get-target-ip">
+    <property name="ant.enable.asserts" value="true"/>
+    <property name="target" value="roboRIO-${team-number}.local" />
+	<echo>Trying Target: ${target}</echo>
+	 <if>
+		<isreachable host="${target}" timeout="5"/>
+	  <then>
+		<echo>roboRIO found via mDNS</echo>
+	  </then>
+	  <else>
+		<var name="target" unset="true"/>
+		<echo> roboRIO not found via mDNS, falling back to static USB</echo>
+		<property name="target" value="172.22.11.2"/>
+		<if>
+			<isreachable host="${target}" timeout="5"/>
+		  <then>
+			<echo>roboRIO found via static USB</echo>
+		  </then>
+		  <else>
+			<var name="target" unset="true"/>
+			<math result="ip.upper" operand1="${team-number}" operation="/" operand2="100" datatype="int"/>
+			<math result="ip.lower" operand1="${team-number}" operation="%" operand2="100" datatype="int"/>
+			<property name="target" value="10.${ip.upper}.${ip.lower}.2"/>
+			<echo>roboRIO not found via USB, falling back to static address of ${target}</echo>
+			<assert name="roboRIOFound" message="roboRIO not found, please check that the roboRIO is connected, imaged and that the team number is set properly in Eclipse">
+				<bool>
+					<isreachable host="${target}" timeout="5"/>
+				</bool>
+			</assert>
+			<echo>roboRIO found via Ethernet static</echo>
+		  </else>
+		</if>
+	  </else>
+	 </if>
+  </target>
+
+  <target name="compile" description="Compile the source code.">
+    <mkdir dir="${build.dir}"/>
+    <echo>[athena-compile] Compiling ${src.dir} with classpath=${classpath} to ${build.dir}</echo>
+
+    <javac srcdir="${src.dir}"
+     destdir="${build.dir}"
+     includeAntRuntime="no"
+     includeJavaRuntime="no"
+     classpath="${classpath}"
+     target="${ant.java.version}"
+     source="${ant.java.version}"
+     compiler="javac${ant.java.version}"
+     debug="true">
+    </javac>
+  </target>
+
+  <target name="jar" depends="compile">
+    <echo>[athena-jar] Making jar ${dist.jar}.</echo>
+    <mkdir dir="${dist.dir}" />
+    <mkdir dir="${build.jars}" />
+
+  <echo>[athena-jar] Copying jars from ${classpath} to ${build.jars}.</echo>
+  <copy todir="${build.jars}" flatten="true">
+    <path>
+    <pathelement path="${classpath}"/>
+    </path>
+  </copy>
+
+    <jar destfile="${dist.jar}" update="false">
+      <manifest>
+    	<attribute name="Main-Class" value="edu.wpi.first.wpilibj.RobotBase"/>
+    	<attribute name="Robot-Class" value="${robot.class}"/>
+    	<attribute name="Class-Path" value="."/>
+		<attribute name="Code-Version" value="${code-version}"/> <!-- git version -->
+      </manifest>
+
+      <fileset dir="${build.dir}" includes="**/*.class"/>
+
+    <zipgroupfileset dir="${build.jars}">
+      <include name="**/*.jar" />
+    </zipgroupfileset>
+    </jar>
+  </target>
+
+    <!-- We're running a clean here to get around a known ant issue where it does not detected changed constant variables.
+     To get around this, we're recompiling the entire project, which is not an issue for most teams. If this is an issue
+     for you, you can remove the clean here, just be sure to do a full rebuild after you've changed any constants.
+     Reference: http://stackoverflow.com/questions/6430001/ant-doesnt-recompile-constants -->	
+  <target name="deploy" depends="clean,jar,get-target-ip,dependencies" description="Deploy the jar and start the program running.">
+    <echo>[athena-deploy] Copying code over.</echo>
+    <scp file="${dist.jar}" todir="${username}@${target}:${deploy.dir}" password="${password}" trust="true"/>
+    <scp file="${wpilib.ant.dir}/robotCommand" todir="${username}@${target}:${command.dir}" password="${password}" trust="true"/>
+
+    <echo>[athena-deploy] Starting program.</echo>
+    <sshexec host="${target}"
+       username="${username}"
+       password="${password}"
+       trust="true"
+       command="${deploy.kill.command};"/>
+
+  </target>
+
+  <target name="debug-deploy" depends="jar,get-target-ip,dependencies" description="Deploy the jar and start the program running.">
+    <echo>[athena-deploy] Copying code over.</echo>
+    <scp file="${dist.jar}" todir="${username}@${target}:${deploy.dir}" password="${password}" trust="true"/>
+  	<!-- The remoteDebugCommand file is used by /usr/local/frc/bin/frcRunRobot.sh on the roboRIO  -->
+    <scp file="${wpilib.ant.dir}/robotDebugCommand" todir="${username}@${target}:${command.dir}" password="${password}" trust="true"/>
+  	<!-- The frcdebug file is used as a flag for /usr/local/frc/bin/frcRunRobot.sh to run the robot program in debug mode -->
+  	<scp file="${wpilib.ant.dir}/frcdebug" todir="${username}@${target}:${debug.flag.dir}" password="${password}" trust="true"/>
+	<sshexec host="${target}"
+        username="${username}"
+        password="${password}"
+        trust="true"
+        command="${debug.flag.command}"/>
+
+    <echo>[athena-deploy] Starting Debug program.</echo>
+    <sshexec host="${target}"
+        username="${username}"
+        password="${password}"
+        trust="true"
+        command="${deploy.kill.command}"/>
+
+  </target>
+
+  <!-- Simulate -->
+  <target name="jar-for-simulation" depends="compile">
+	<echo>[jar-for-simulation] Building jar.</echo>
+
+	<jar destfile="${simulation.dist.jar}">
+	  <manifest>
+		<attribute name="Built-By" value="${user.name}"/>
+		<attribute name="Robot-Class" value="${robot.class}"/>
+		<attribute name="Main-Class" value="edu.wpi.first.wpilibj.RobotBase"/>
+		<attribute name="Code-Version" value="${code-version}"/> <!-- git version -->
+	  </manifest>
+	  <fileset dir="${build.dir}" />
+	  <zipgroupfileset dir="${wpilib.sim.lib}">
+	  	<include name="**/*.jar" />
+	  </zipgroupfileset>
+	</jar>
+  </target>
+
+  <target name="simulate" depends="jar-for-simulation">
+    <parallel>
+      <sequential>
+	    <echo>[simulate] Running Gazebo.</echo>
+	    <exec executable="frcsim">
+	      <arg value="${simulation.world.file}"/>
+	    </exec>
+      </sequential>
+      <sequential>
+        <sleep seconds="5"/>
+	    <echo>[simulate] Running DriverStation.</echo>
+	    <java jar="${wpilib.sim.tools}/SimDS.jar" fork="true">
+          <jvmarg value="-Djava.library.path=${wpilib.sim.lib}" />
+        </java>
+      </sequential>
+      <sequential>
+        <sleep seconds="5"/>
+	    <echo>[simulate] Running Code.</echo>
+	    <java jar="${simulation.dist.jar}" fork="true">
+          <jvmarg value="-Djava.library.path=${wpilib.sim.lib}" />
+        </java>
+      </sequential>
+    </parallel>
+  </target>
+
+  <target name="debug-simulate" depends="jar-for-simulation">
+    <parallel>
+      <sequential>
+	    <echo>[debug-simulate] Running Gazebo.</echo>
+	    <exec executable="frcsim">
+	      <arg value="${simulation.world.file}"/>
+	    </exec>
+      </sequential>
+      <sequential>
+        <sleep seconds="5"/>
+	    <echo>[debug-simulate] Running DriverStation.</echo>
+	    <java jar="${wpilib.sim.tools}/SimDS.jar" fork="true">
+          <jvmarg value="-Djava.library.path=${wpilib.sim.lib}" />
+        </java>
+      </sequential>
+      <sequential>
+        <sleep seconds="5"/>
+	    <echo>[debug-simulate] Running Code.</echo>
+	    <java jar="${simulation.dist.jar}" fork="true">
+          <jvmarg value="-Xdebug" />
+          <jvmarg value="-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8348" />
+          <jvmarg value="-Djava.library.path=${wpilib.sim.lib}" />
+        </java>
+      </sequential>
+    </parallel>
+  </target>
+  
+  <target name="dependencies" depends="get-target-ip">
+    <property name="ant.enable.asserts" value="true"/>
+	<post to="http://${target}/nisysapi/server" logfile="sysProps.xml" verbose="false" encoding="UTF-16LE" append="false">
+		<prop name="Function" value="GetPropertiesOfItem"/>
+		<prop name="Plugins" value="nisyscfg"/>
+		<prop name="Items" value="system"/>
+	</post>
+	<loadfile srcFile="sysProps.xml" encoding="UTF-16LE" property="roboRIOSysValues"/>
+	<propertyregex property="roboRIOImage" input="${roboRIOSysValues}" regexp="FRC_roboRIO_2015_v([0-9]+)" select="\1" defaultValue="ImageRegExFail"/>
+	<assert message="roboRIO Image does not match plugin, allowed image version: ${roboRIOAllowedImages}">
+		<bool>
+			<contains string="${roboRIOAllowedImages}" substring="${roboRIOImage}"/>
+		</bool>
+	</assert>
+	<echo>roboRIO image version validated</echo>
+	<echo>Checking for JRE. If this fails install the JRE using these instructions: https://wpilib.screenstepslive.com/s/4485/m/13503/l/288822-installing-java-8-on-the-roborio-using-the-frc-roborio-java-installer-java-only</echo>
+	<sshexec host="${target}"
+        username="${username}"
+        password="${password}"
+        trust="true"
+		failonerror="true"
+        command="test -d ${roboRIOJRE.dir}"/>
+  </target>
+</project>

--- a/RobotCode/MecanumDrive/custom_wpi_build.xml
+++ b/RobotCode/MecanumDrive/custom_wpi_build.xml
@@ -1,8 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!-- 
 NONE OF THIS IS MINE. This is the standard WPI build script with two small additions at lines 94 and 154. Go bug them if it doesn't work!
 -->
 
-<?xml version="1.0" encoding="UTF-8"?>
 
 <project name="athena-project-build" default="deploy">
 


### PR DESCRIPTION
This is an ant script which takes the output of `git rev-parse head` and shoves it in any compiled jars.  
For the less git-inclined, `rev-parse head` returns the current git commit hash.

The process is all automated with ant, and shouldn't require any special code by whomever chooses to deploy.
