### PR TITLE
Making changes to increase some readability and best practices.

### DIFF
--- a/RobotCode/MecanumDrive/src/org/usfirst/frc4915/MecanumDrive/OI.java
+++ b/RobotCode/MecanumDrive/src/org/usfirst/frc4915/MecanumDrive/OI.java
@@ -134,22 +134,5 @@ public class OI {
         String parsedVersion = VersionFinder.parseVersionFromManifest(this);
         SmartDashboard.putString("Code Version", parsedVersion == null? "<not found>" : parsedVersion);
     }
-    
-    /**
-     * For driving
-     * @return the drive stick
-     */
-    public Joystick getDriveStick1() {
-        return driveStick;
-    }
-
-    /**
-     * For lifting
-     * @return the elevator stick
-     */
-    public Joystick getElevatorStick() {
-    	return elevatorStick;
-    }
-
 }
 

--- a/RobotCode/MecanumDrive/src/org/usfirst/frc4915/MecanumDrive/commands/ArcadeDrive.java
+++ b/RobotCode/MecanumDrive/src/org/usfirst/frc4915/MecanumDrive/commands/ArcadeDrive.java
@@ -21,7 +21,7 @@ public class ArcadeDrive extends Command {
     // Called repeatedly when this Command is scheduled to run
     protected void execute() {
     	//TODO read joystick value for thottle and update motor values with the modified throttle
-    	Robot.driveTrain.arcadeDrive(Robot.oi.getDriveStick1());
+    	Robot.driveTrain.arcadeDrive(Robot.oi.driveStick);
     	
     }
 

--- a/RobotCode/MecanumDrive/src/org/usfirst/frc4915/MecanumDrive/commands/ElevatorFineTune.java
+++ b/RobotCode/MecanumDrive/src/org/usfirst/frc4915/MecanumDrive/commands/ElevatorFineTune.java
@@ -25,7 +25,7 @@ public class ElevatorFineTune extends Command {
 
     // Called repeatedly when this Command is scheduled to run
     protected void execute() {
-    	elevator.moveAtSpeed(Robot.oi.getElevatorStick());
+    	elevator.moveAtSpeed(Robot.elevatorStick());
     }
 
     // Make this return true when this Command no longer needs to run execute()

--- a/RobotCode/MecanumDrive/src/org/usfirst/frc4915/MecanumDrive/commands/ElevatorFineTune.java
+++ b/RobotCode/MecanumDrive/src/org/usfirst/frc4915/MecanumDrive/commands/ElevatorFineTune.java
@@ -25,7 +25,7 @@ public class ElevatorFineTune extends Command {
 
     // Called repeatedly when this Command is scheduled to run
     protected void execute() {
-    	elevator.moveAtSpeed(Robot.elevatorStick());
+    	elevator.moveAtSpeed(Robot.oi.elevatorStick());
     }
 
     // Make this return true when this Command no longer needs to run execute()

--- a/RobotCode/MecanumDrive/src/org/usfirst/frc4915/MecanumDrive/commands/MecanumDrive.java
+++ b/RobotCode/MecanumDrive/src/org/usfirst/frc4915/MecanumDrive/commands/MecanumDrive.java
@@ -39,7 +39,7 @@ public class  MecanumDrive extends Command {
 
     // Called repeatedly when this Command is scheduled to run
     protected void execute() {
-    	Joystick joystickDrive = Robot.oi.getDriveStick1();
+    	Joystick joystickDrive = Robot.oi.driveStick;
     	Robot.driveTrain.mecanumDrive(joystickDrive);
     }
 

--- a/RobotCode/MecanumDrive/src/org/usfirst/frc4915/MecanumDrive/subsystems/Elevator.java
+++ b/RobotCode/MecanumDrive/src/org/usfirst/frc4915/MecanumDrive/subsystems/Elevator.java
@@ -49,13 +49,7 @@ public class Elevator extends Subsystem {
 
 	public boolean isInPosition(double position) {
 		// tells if the elevator is in a specific preset position
-		
-		if (Math.abs(position - getPosition()) <= 1) {
-			return true;
-		}
-		else {
-			return false;
-		}
+		return Math.abs(position - getPosition() <= 1);
 	}
     
     public void moveToPosition(double position) {

--- a/RobotCode/MecanumDrive/src/org/usfirst/frc4915/MecanumDrive/subsystems/Elevator.java
+++ b/RobotCode/MecanumDrive/src/org/usfirst/frc4915/MecanumDrive/subsystems/Elevator.java
@@ -49,7 +49,7 @@ public class Elevator extends Subsystem {
 
 	public boolean isInPosition(double position) {
 		// tells if the elevator is in a specific preset position
-		return Math.abs(position - getPosition() <= 1);
+		return Math.abs(position - getPosition()) <= 1;
 	}
     
     public void moveToPosition(double position) {


### PR DESCRIPTION
Stick to a style with getters/setters and public/private pairs. With the majority of the code being public classes, variables are directly accessible and "get" methods are not needed. Removed redundancy in OI.java
Instead of evaluating an inequality and then return "true" or "false," simply return the expression you are testing. Simpler and promotes best practice.
